### PR TITLE
feat(backup,dns): migrate certbot and restic from Linode to Hetzner

### DIFF
--- a/ansible/playbooks/all/borg-backup-all.yml
+++ b/ansible/playbooks/all/borg-backup-all.yml
@@ -1,5 +1,5 @@
 - name: Run borg backup on all configured servers to have the most up-to-date backup
-  hosts: "{{ variable_host | default('all:!proxmox:!linode_dmz_bastion') }}"
+  hosts: "{{ variable_host | default('all:!proxmox') }}"
   ignore_unreachable: true
   gather_facts: false
 

--- a/ansible/playbooks/lxc/backup-init.yml
+++ b/ansible/playbooks/lxc/backup-init.yml
@@ -7,12 +7,14 @@
     ansible_host: "{{ hostvars[inventory_hostname].ansible_host }}"
     lxc_host: "{{ hostvars[inventory_hostname].lxc_host }}"
     repositories_dir: /backup/repos
-    linode_access_key: "{{ lookup('file', '../../../secrets/backup/resticprofile/access_key') }}"
-    linode_secret_key: "{{ lookup('file', '../../../secrets/backup/resticprofile/secret_key') }}"
+    # Storage Box SSH listens on 23, not 22, and restic's sftp backend has no
+    # port option -- hence the ssh config alias written below.
+    hetzner_storagebox_host: "{{ lookup('file', '../../../secrets/hetzner/storagebox_host') | trim }}"
+    hetzner_storagebox_port: 23
     resticprofile_configurations:
       - global
-      - borg-to-linode-s3
-      - immich-media-to-linode-s3
+      - borg-to-hetzner-storagebox
+      - immich-media-to-hetzner-storagebox
   roles:
     - role: lxc_python3
     - role: node_exporter
@@ -85,6 +87,41 @@
         group: backup
         mode: '0600'
 
+    - name: Create backup .ssh directory
+      ansible.builtin.file:
+        path: /home/backup/.ssh
+        state: directory
+        owner: backup
+        group: backup
+        mode: '0700'
+    - name: Install Storage Box SSH key
+      ansible.builtin.copy:
+        src: ../../../secrets/hetzner/storage_box_ssh_key
+        dest: /home/backup/.ssh/hetzner_storagebox
+        owner: backup
+        group: backup
+        mode: '0600'
+    # restic addresses the repository as sftp:hetzner-storagebox:..., so this
+    # alias is what supplies the non-standard port and the key. Host key
+    # checking is off because the backup runs unattended from cron and a
+    # rebuilt container has no known_hosts -- the same trade already made for
+    # the borg clients.
+    - name: Configure ssh alias for the Storage Box
+      ansible.builtin.copy:
+        content: |
+          Host hetzner-storagebox
+              HostName {{ hetzner_storagebox_host }}
+              Port {{ hetzner_storagebox_port }}
+              User {{ hetzner_storagebox_host.split('.')[0] }}
+              IdentityFile /home/backup/.ssh/hetzner_storagebox
+              StrictHostKeyChecking no
+              UserKnownHostsFile /dev/null
+              BatchMode yes
+        dest: /home/backup/.ssh/config
+        owner: backup
+        group: backup
+        mode: '0600'
+
     - name: Install restic
       ansible.builtin.apk:
         name: restic
@@ -118,8 +155,13 @@
         owner: backup
         group: backup
         mode: '0700'
+    # profiles.yaml is rebuilt by concatenating the templates below, so it is
+    # removed first to keep the play idempotent rather than appending forever.
     - name: Clean up resticprofile configurations
-      ansible.builtin.command: rm -f /home/backup/.config/resticprofile/profiles.yaml
+      ansible.builtin.file:
+        path: /home/backup/.config/resticprofile/profiles.yaml
+        state: absent
+      changed_when: false
     - name: Copy resticprofile configurations
       ansible.builtin.template:
         src: ../../../configs/backup/resticprofile/{{ item }}.yaml.j2
@@ -141,6 +183,22 @@
         mode: '0400'
         owner: backup
         group: backup
+    # restic's sftp backend creates the repository directory but not its
+    # parents, so a fresh Storage Box needs the tree laid out first or every
+    # init fails with "mkdir: file does not exist". Done over SFTP rather than
+    # `ssh ... mkdir` because SFTP is the one interface a Storage Box is
+    # guaranteed to expose; the restricted SSH shell varies by plan. The
+    # leading `-` tells sftp to carry on when a directory already exists.
+    - name: Ensure the Storage Box parent directories exist
+      ansible.builtin.shell:
+        cmd: |
+          printf -- '-mkdir backups\n-mkdir backups/borg\n' | sftp -b - hetzner-storagebox
+      changed_when: false
+      become: true
+      become_user: backup
+      become_method: su
+      become_flags: '-s /bin/sh'
+
     - name: Init restic repositories if they don't already exist
       ansible.builtin.command: resticprofile {{ item }}.init
       with_items: "{{ repositories + ['immich-media'] }}"

--- a/ansible/playbooks/lxc/backup-init.yml
+++ b/ansible/playbooks/lxc/backup-init.yml
@@ -11,6 +11,12 @@
     # port option -- hence the ssh config alias written below.
     hetzner_storagebox_host: "{{ lookup('file', '../../../secrets/hetzner/storagebox_host') | trim }}"
     hetzner_storagebox_port: 23
+    # Host key lines as published by Hetzner, in known_hosts format. Pinned
+    # rather than accepted on first use: this is the one backup hop that leaves
+    # the network, so the server gets authenticated. Restic encrypts the
+    # payload either way, but without this an active attacker can impersonate
+    # the Storage Box instead of merely observing ciphertext.
+    hetzner_storagebox_host_key: "{{ lookup('file', '../../../secrets/hetzner/storagebox_host_key') }}"
     resticprofile_configurations:
       - global
       - borg-to-hetzner-storagebox
@@ -101,11 +107,17 @@
         owner: backup
         group: backup
         mode: '0600'
+    - name: Pin the Storage Box host key
+      ansible.builtin.copy:
+        content: "{{ hetzner_storagebox_host_key }}"
+        dest: /home/backup/.ssh/known_hosts_hetzner
+        owner: backup
+        group: backup
+        mode: '0600'
     # restic addresses the repository as sftp:hetzner-storagebox:..., so this
-    # alias is what supplies the non-standard port and the key. Host key
-    # checking is off because the backup runs unattended from cron and a
-    # rebuilt container has no known_hosts -- the same trade already made for
-    # the borg clients.
+    # alias is what supplies the non-standard port, the key and the pinned host
+    # key. Unlike the borg clients on the LAN, this connection leaves the
+    # network, so it verifies the server rather than trusting on first use.
     - name: Configure ssh alias for the Storage Box
       ansible.builtin.copy:
         content: |
@@ -114,8 +126,9 @@
               Port {{ hetzner_storagebox_port }}
               User {{ hetzner_storagebox_host.split('.')[0] }}
               IdentityFile /home/backup/.ssh/hetzner_storagebox
-              StrictHostKeyChecking no
-              UserKnownHostsFile /dev/null
+              IdentitiesOnly yes
+              StrictHostKeyChecking yes
+              UserKnownHostsFile /home/backup/.ssh/known_hosts_hetzner
               BatchMode yes
         dest: /home/backup/.ssh/config
         owner: backup

--- a/ansible/playbooks/lxc/dmz-proxy-init.yml
+++ b/ansible/playbooks/lxc/dmz-proxy-init.yml
@@ -11,7 +11,16 @@
       - "*.dormlab.tarasa24.dev"
       - "*.lan.tarasa24.dev"
     certbot_email: "admin@tarasa24.dev"
-    certbot_linode_credentials: "{{ lookup('file', '../../../secrets/linode/certbot_acme_api_creds.ini') }}"
+    # certbot-dns-hetzner is not in any stable Alpine release -- only in
+    # edge/testing -- and putting the sole ingress host on a rolling base is a
+    # worse trade than a venv. Wildcards make DNS-01 mandatory, so the plugin
+    # itself is not optional. 4.x talks to the Hetzner *Cloud* DNS API and needs
+    # a Cloud API token; if the zone is ever moved to the classic DNS console
+    # (dns.hetzner.com) this must go back to 3.x, which supports both.
+    certbot_venv: /opt/certbot
+    certbot_version: "5.7.0"
+    certbot_dns_hetzner_version: "4.0.0"
+    hetzner_dns_api_token: "{{ lookup('file', '../../../secrets/hetzner/certbot_dns_api_token') | trim }}"
   roles:
     - role: lxc_python3
     - role: borgmatic
@@ -27,9 +36,26 @@
     # allow 443/80/53 outbound explicitly -- see terraform/lxc_dmz_proxy.tf.
     - name: Generate SSL certificates
       block:
-        - name: Install Certbot
+        # cryptography and cffi publish musllinux wheels, so nothing should
+        # actually compile here; the toolchain is present so that a version
+        # bump landing without a wheel degrades to a slow install rather than a
+        # hard failure. If a future pin needs to build cryptography from source
+        # it will also want rust and cargo, which are deliberately not
+        # installed -- this container has a 5G disk.
+        - name: Install build prerequisites for the Certbot venv
           ansible.builtin.package:
-            name: [certbot, certbot-dns-linode]
+            name: [python3, py3-pip, gcc, musl-dev, python3-dev, libffi-dev, openssl-dev]
+            state: present
+        - name: Create the Certbot venv
+          ansible.builtin.command: python3 -m venv {{ certbot_venv }}
+          args:
+            creates: "{{ certbot_venv }}/bin/python"
+        - name: Install pinned Certbot and the Hetzner DNS plugin
+          ansible.builtin.pip:
+            name:
+              - "certbot=={{ certbot_version }}"
+              - "certbot-dns-hetzner=={{ certbot_dns_hetzner_version }}"
+            virtualenv: "{{ certbot_venv }}"
             state: present
         - name: Create Certbot folder - /etc/letsencrypt
           file:
@@ -38,22 +64,42 @@
             owner: root
             group: root
             mode: 0700
-        - name: Create Linode API key file
+        - name: Create Hetzner DNS API credentials file
           ansible.builtin.copy:
-            content: "{{ certbot_linode_credentials }}"
-            dest: /etc/letsencrypt/linode.ini
+            content: "dns_hetzner_api_token = {{ hetzner_dns_api_token }}\n"
+            dest: /etc/letsencrypt/hetzner.ini
             mode: "0600"
         - name: Check if certificates should be generated (they dont exist or are expired)
-          ansible.builtin.command: certbot certificates --cert-name {{ item }}
+          ansible.builtin.command: "{{ certbot_venv }}/bin/certbot certificates --cert-name {{ item }}"
           register: certbot_certificates
           ignore_errors: true
           with_items: "{{ certificates }}"
+        # Third-party plugins do not get a --dns-<name> shorthand; that is only
+        # generated for the plugins certbot bundles itself. The credentials path
+        # must be absolute, per the plugin's own documentation.
         - name: Certbot - Generate SSL certificates
-          ansible.builtin.command: certbot certonly --dns-linode --dns-linode-credentials /etc/letsencrypt/linode.ini --dns-linode-propagation-seconds 60 --email {{ certbot_email }} --agree-tos --no-eff-email --cert-name {{ item }} -d {{ item }} # --test-cert
+          ansible.builtin.command: >-
+            {{ certbot_venv }}/bin/certbot certonly
+            --authenticator dns-hetzner
+            --dns-hetzner-credentials /etc/letsencrypt/hetzner.ini
+            --dns-hetzner-propagation-seconds 60
+            --email {{ certbot_email }} --agree-tos --no-eff-email
+            --cert-name {{ item }} -d {{ item }}
           args:
             creates: "/etc/letsencrypt/renewal/{{ item }}.conf"
           with_items: "{{ certificates }}"
           when: certbot_certificates.results[loop.index0].rc != 0 or 'Certificate not yet due for renewal' in certbot_certificates.results[loop.index0].stderr
+        # The Alpine certbot package used to bring its own periodic renewal job,
+        # which called /usr/bin/certbot. That binary is gone now, so renewal has
+        # to be scheduled explicitly or the certs simply expire in ~60 days with
+        # nothing failing loudly until TLSCertExpiringSoon fires.
+        - name: Schedule Certbot renewal
+          ansible.builtin.cron:
+            name: "Renew TLS certificates"
+            job: "{{ certbot_venv }}/bin/certbot renew --quiet --deploy-hook 'nginx -s reload'"
+            minute: "17"
+            hour: "3,15"
+            state: present
 
     - name: Setup GeoIP2
       block:

--- a/configs/backup/resticprofile/borg-to-hetzner-storagebox.yaml.j2
+++ b/configs/backup/resticprofile/borg-to-hetzner-storagebox.yaml.j2
@@ -1,10 +1,10 @@
 {% for repository_name in repositories %}
 {{ repository_name }}:
-  repository: s3:eu-central-1.linodeobjects.com/homelab-borg-backups/{{ repository_name }}
+  # sftp:<ssh-host-alias>:<path>. The alias resolves via /home/backup/.ssh/config,
+  # which pins port 23 and the key -- restic's sftp backend gives no way to pass
+  # a port, so the alias is doing real work here, not just shortening the line.
+  repository: sftp:hetzner-storagebox:backups/borg/{{ repository_name }}
   password-file: /home/backup/.config/resticprofile/restic-password.txt
-  env:
-    AWS_ACCESS_KEY_ID: {{ linode_access_key }}
-    AWS_SECRET_ACCESS_KEY: {{ linode_secret_key }}
 
   retention:
     after-backup: true

--- a/configs/backup/resticprofile/immich-media-to-hetzner-storagebox.yaml.j2
+++ b/configs/backup/resticprofile/immich-media-to-hetzner-storagebox.yaml.j2
@@ -1,9 +1,9 @@
 immich-media:
-  repository: s3:eu-central-1.linodeobjects.com/homelab-immich-media-backups
+  # sftp:<ssh-host-alias>:<path>. The alias resolves via /home/backup/.ssh/config,
+  # which pins port 23 and the key -- restic's sftp backend gives no way to pass
+  # a port, so the alias is doing real work here, not just shortening the line.
+  repository: sftp:hetzner-storagebox:backups/immich-media
   password-file: /home/backup/.config/resticprofile/restic-password.txt
-  env:
-    AWS_ACCESS_KEY_ID: {{ linode_access_key }}
-    AWS_SECRET_ACCESS_KEY: {{ linode_secret_key }}
 
   retention:
     after-backup: true


### PR DESCRIPTION
Part of #3. Closes #5.

Stacked on #<PR 1>. **Base is `feature/network-overhaul`**, not `master` — this
edits `dmz-proxy-init.yml`, which only exists on that branch. GitHub will
retarget once PR 1 merges.

Two commits: the migration, and a follow-up hardening fix.

## Certbot: Linode DNS → Hetzner Cloud DNS

Installed into a **pinned pip venv at `/opt/certbot`** rather than as an Alpine
package. `certbot-dns-hetzner` exists only in Alpine **edge/testing**
(`4.0.0-r0`), and putting the sole internet ingress and TLS terminator on a
rolling base is a worse trade than a venv. The certs are wildcards
(`*.homelab`, `*.dormlab`, `*.lan`), so DNS-01 is mandatory and the plugin is
not optional.

```
certbot==5.7.0
certbot-dns-hetzner==4.0.0
```

### Three corrections to #5 as written

- **`--dns-hetzner` would not have worked.** The `--dns-<name>` shorthand is
  only generated for the plugins certbot bundles itself; third-party plugins
  need `--authenticator dns-hetzner`. Credentials path must also be absolute,
  which the plugin's docs call out explicitly.
- **Plugin 4.x speaks only the Hetzner _Cloud_ DNS API** (`hcloud>=2.17.1`).
  3.x handles both Cloud and the classic `dns.hetzner.com` console; 2.x only
  the classic one. 4.0.0 is pinned because the zone is going into Cloud DNS —
  if that ever changes, this must drop to 3.x. Commented at the pin.
- **Take the nameservers from the Cloud console**, not the
  `helium/oxygen/hydrogen.ns.hetzner.com` list in the issue — that is the
  classic DNS product's set. Verify with `dig NS tarasa24.dev` before and after.

### Renewal was never scheduled in this repo

There is no `certbot renew` cron anywhere in the tree. Renewal relied on
whatever the Alpine `certbot` package installed, which invoked
`/usr/bin/certbot` — a path that ceases to exist the moment we move to a venv.
Nothing would have failed loudly until `TLSCertExpiringSoon` fired at 7 days
out.

Now scheduled explicitly, twice daily with jitter, with
`--deploy-hook 'nginx -s reload'` so a renewal actually gets served.

## Restic: Linode Object Storage → Hetzner Storage Box

Repository moves from `s3:eu-central-1.linodeobjects.com/...` to
`sftp:hetzner-storagebox:backups/borg/<repo>` (and `backups/immich-media`); the
`AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` env block is gone. Retention,
schedules and the borg `run-before`/`run-after` hooks are unchanged.

Storage Box SSH listens on **port 23** and restic's sftp backend has no port
option, so connection details live in an ssh config alias for the `backup`
user. The alias is doing real work, not just shortening the URL.

### restic cannot create its own parent directories

`restic init` over sftp creates the repository directory and its internals but
**not** intermediate parents. On a fresh Storage Box every
`resticprofile <x>.init` would have hard-failed with
`mkdir: file does not exist`. The play now lays out `backups/borg/` first.

Done over `sftp -b` rather than `ssh … mkdir`: SFTP is the one interface a
Storage Box always exposes, while the restricted SSH shell varies by plan. The
leading `-` on each command makes it idempotent.

## Second commit: host key pinning

The initial ssh alias copied `StrictHostKeyChecking no` +
`UserKnownHostsFile /dev/null` from the borg clients. That is defensible on the
LAN and wrong on the one backup hop that leaves the network — it means the
server is never authenticated.

Restic encrypts the payload client-side before anything is sent, so an observer
only ever sees ciphertext either way. But without server authentication, an
attacker able to intercept can *impersonate* the Storage Box rather than merely
watch it. Host key lines now come from git-crypt and are pinned in a dedicated
`known_hosts` file, with `IdentitiesOnly yes` so only the intended key is
offered.

**Take the fingerprints from the Hetzner console**, not from a first
connection — otherwise this is trust-on-first-use with extra steps.

## Encryption posture, for the record

| Hop | In transit | At rest |
|---|---|---|
| service host → backup (1013) | borg over SSH | **plaintext** (`--encryption=none`) |
| backup → Storage Box | SFTP over SSH, host key pinned | **encrypted** — restic AES-256-CTR + Poly1305-AES |
| immich media → Storage Box | same | same |

Restic has no unencrypted mode; the repo is encrypted before transmission, so
Hetzner never sees filenames, structure or per-file sizes. Local borg repos
staying plaintext is a deliberate call — physical access to the USB-SSD or root
on PVE is already game over for a homelab, and borg cannot re-encrypt an
existing repository, so changing it would mean discarding all backup history.
Recorded in AGENTS.md by PR 3.

⚠️ Consequence: the restic password lives in
`secrets/backup/resticprofile/restic-password.txt`, encrypted by git-crypt.
**If `crypt.key` is lost, every offsite backup is permanently unrecoverable.**
There is no provider-side recovery path — that is the point of client-side
encryption.

## New secrets required before this is applied

All git-crypt'd, none of them created by this PR:

```
secrets/hetzner/certbot_dns_api_token    # Cloud console > Security > API tokens
secrets/hetzner/storage_box_ssh_key      # private key; pub installed via install-ssh-key
secrets/hetzner/storagebox_host          # u123456.your-storagebox.de — full hostname
secrets/hetzner/storagebox_host_key      # known_hosts format, verified in the console
```

The Storage Box username is derived as `storagebox_host.split('.')[0]`, so that
file must hold the complete hostname, not just the `u123456` part.

## Ordering

**Do not switch nameservers to Hetzner until PR 1 has been cut over.** Until
this PR is applied, `dmz-proxy-init.yml` still runs `certbot --dns-linode`
against `secrets/linode/`; if the zone has already moved, the DNS-01 challenge
fails because Linode is no longer authoritative.

Sequence: PR 1 cutover with A records repointed but the zone still at Linode →
this PR → NS switch to Hetzner → PR 3 deletes the Linode account.

Existing certs are on the `/mnt/USB-SSD/ssl` bind mount and survive the
container rebuild, and the certbot task has a `creates:` guard on
`renewal/*.conf`, so issuance is skipped at cutover. Only renewal depends on
this working, which buys roughly 60 days of margin.

## Verification

Static checks done here:
- `ansible-playbook --syntax-check` on both changed playbooks — pass
- No remaining `linode` / `access_key` / `secret_key` / old profile names in
  `ansible/` or `configs/` outside PR-3 scope
- Reviewed by the refine agent; the restic parent-directory blocker was caught
  there and fixed
- Confirmed the profile *names* in the resticprofile templates derive from borg
  config basenames, not the template filenames — so renaming the templates
  leaves no orphaned crontab entries for the `backup` user

On-host, after deploy:
```bash
# dmz-proxy (4010)
/opt/certbot/bin/certbot renew --dry-run

# backup (1013), as the backup user
resticprofile monitoring.init
resticprofile monitoring.backup
resticprofile monitoring.snapshots
```

Confirm the resulting snapshot IDs against the Linode ones recorded during the
pre-flight before letting PR 3 delete anything.